### PR TITLE
Fix stats toggle visibility detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@
 
     // Toggle affichage des statistiques
     statsToggleBtn.addEventListener('click', () => {
-      const isVisible = statsSection.style.display !== 'none';
+      const isVisible = getComputedStyle(statsSection).display !== 'none';
       if (isVisible) {
         statsSection.style.display = 'none';
         statsToggleBtn.textContent = '📊 Voir mes statistiques';


### PR DESCRIPTION
## Summary
- use `getComputedStyle` to determine whether the stats section is currently shown
- ensure the toggle treats the initial hidden state correctly so the first click reveals the stats

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1e9b243f4832c97509cdfad64daea