### PR TITLE
Neutral score color before first answer

### DIFF
--- a/index.html
+++ b/index.html
@@ -790,10 +790,15 @@
     // NOUVELLE FONCTION: Couleurs adaptatives pour le score
     function updateScoreColor() {
       const totalQuestions = currentQuestions.length;
-      if (totalQuestions === 0) return;
+      const answeredQuestions = totalQuestions - availableQuestions.length;
+
+      if (totalQuestions === 0 || answeredQuestions <= 0) {
+        scoreElement.style.color = 'var(--text-color)';
+        return;
+      }
 
       const percentage = (score / totalQuestions) * 100;
-      
+
       if (percentage >= 90) {
         scoreElement.style.color = '#10B981'; // 🟢 Vert pour excellent (90%+)
       } else if (percentage >= 70) {


### PR DESCRIPTION
## Summary
- keep the score display in a neutral color until the first question is answered
- reuse the existing score palette once at least one question has been attempted

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1ea29149c832ca76d2bdc3a3c0010