### PR TITLE
Met à jour la progression du quiz à la fin

### DIFF
--- a/index.html
+++ b/index.html
@@ -808,7 +808,18 @@
     // FONCTION MODIFIÉE: Mettre à jour la barre de progression
     function updateProgress() {
       const totalQuestions = currentQuestions.length;
-      const answeredQuestions = totalQuestions - availableQuestions.length;
+      let answeredQuestions = totalQuestions - availableQuestions.length;
+
+      if (availableQuestions.length === 0 && totalQuestions > 0) {
+        answeredQuestions = totalQuestions;
+      }
+
+      if (answeredQuestions < 0) {
+        answeredQuestions = 0;
+      } else if (answeredQuestions > totalQuestions) {
+        answeredQuestions = totalQuestions;
+      }
+
       const percentage = totalQuestions > 0 ? (answeredQuestions / totalQuestions) * 100 : 0;
       
       document.getElementById('progress-bar').style.width = percentage + '%';
@@ -1236,6 +1247,7 @@
       }
 
       availableQuestions.splice(currentQuestionIndex, 1);
+      updateProgress();
     }
 
     // Génère le texte de partage


### PR DESCRIPTION
## Summary
- améliore `updateProgress` pour plafonner les réponses terminées et afficher la progression finale lorsque toutes les questions sont répondues
- déclenche `updateProgress` dès qu'une réponse est sélectionnée afin de refléter immédiatement la progression finale

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1e9aaff2c832cb9a0a0eee87b2f9b