### PR TITLE
Nettoie les résumés avant chaque redémarrage de quiz

### DIFF
--- a/index.html
+++ b/index.html
@@ -1063,7 +1063,17 @@
       isRevisionMode = false;
       revisionQuestions = [];
       quizModeInfo.textContent = '';
-      
+
+      const existingEndMessage = quizArea.querySelector('#end-message');
+      if (existingEndMessage) {
+        existingEndMessage.remove();
+      }
+
+      const existingStudyLinks = quizArea.querySelector('.study-links');
+      if (existingStudyLinks) {
+        existingStudyLinks.remove();
+      }
+
       if (currentQuestions.length === 0) {
         quizArea.classList.remove('hidden');
         document.getElementById('progress-container').style.display = 'none';


### PR DESCRIPTION
## Summary
- nettoie l'aire du quiz en retirant les anciens messages de fin et liens d'étude dès le redémarrage
- garantit que chaque nouveau quiz affiche un résumé unique après la relance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1e956dbac832cb9d64665eec8bd8e