### PR TITLE
Add questions for 22–28 septembre study week

### DIFF
--- a/questions.json
+++ b/questions.json
@@ -1204,12 +1204,178 @@
   ]
 },
   "22–28 septembre | D&A 106–108": {
-    "jour1": [],
-    "jour2": [],
-    "jour3": [],
-    "jour4": [],
-    "jour5": []
+    "jour1": [
+      {
+        "question": "Selon D&A 106:1-3, quelle responsabilité le Seigneur confie-t-il à Warren Cowdery ?",
+        "answers": [
+          {"text": "Veiller sur l'Église à Freedom et proclamer l'Évangile", "correct": true},
+          {"text": "Organiser une compagnie commerciale dans le Missouri", "correct": false},
+          {"text": "Superviser la construction du temple de Kirtland", "correct": false}
+        ]
+      },
+      {
+        "question": "Que nous apprend D&A 106:4-5 sur la venue du Seigneur ?",
+        "answers": [
+          {"text": "Elle surprendra ceux qui ne veillent pas, comme un voleur dans la nuit", "correct": true},
+          {"text": "Elle sera annoncée par un décret du gouvernement", "correct": false},
+          {"text": "Elle ne viendra qu'après que tous auront été convertis", "correct": false}
+        ]
+      },
+      {
+        "question": "Quelle promesse le Seigneur donne-t-il concernant la maison de Warren Cowdery (D&A 106:6-8) ?",
+        "answers": [
+          {"text": "Sa maison sera bénie s'ils demeurent fidèles", "correct": true},
+          {"text": "Ils seront transportés immédiatement à Kirtland", "correct": false},
+          {"text": "Ils recevront des richesses temporelles garanties", "correct": false}
+        ]
+      },
+      {
+        "question": "Quel conseil personnel le Seigneur donne-t-il à Warren Cowdery dans D&A 106:7 ?",
+        "answers": [
+          {"text": "Sois humble et demeure fidèle, et je te soutiendrai", "correct": true},
+          {"text": "Prends du repos et laisse d'autres servir à ta place", "correct": false},
+          {"text": "Cherche d'abord des honneurs politiques", "correct": false}
+        ]
+      }
+    ],
+    "jour2": [
+      {
+        "question": "Pourquoi le sacerdoce supérieur porte-t-il le nom de Melchisédek selon D&A 107:2-4 ?",
+        "answers": [
+          {"text": "Pour honorer le grand prêtre Melchisédek et éviter de répéter trop souvent le nom de Dieu", "correct": true},
+          {"text": "Parce que Melchisédek fut le premier à recevoir le sacerdoce d'Aaron", "correct": false},
+          {"text": "Parce que Melchisédek était un lévite", "correct": false}
+        ]
+      },
+      {
+        "question": "Quel pouvoir principal le sacerdoce de Melchisédek détient-il (D&A 107:8) ?",
+        "answers": [
+          {"text": "Le pouvoir de présider l'Église et d'administrer toutes ses ordonnances", "correct": true},
+          {"text": "Seulement le pouvoir de baptiser", "correct": false},
+          {"text": "Uniquement le pouvoir de diriger les réunions de jeûne", "correct": false}
+        ]
+      },
+      {
+        "question": "Quelles clés détient le sacerdoce d'Aaron selon D&A 107:13-14 ?",
+        "answers": [
+          {"text": "Les clés du ministère des anges, de l'Évangile de repentance et du baptême", "correct": true},
+          {"text": "Les clés de la création du monde", "correct": false},
+          {"text": "Les clés du scellement éternel", "correct": false}
+        ]
+      },
+      {
+        "question": "Quel office préside le sacerdoce d'Aaron (D&A 107:15-17) ?",
+        "answers": [
+          {"text": "L'évêque, qui est juge commun en Israël", "correct": true},
+          {"text": "Le patriarche de chaque famille", "correct": false},
+          {"text": "Le président du conseil des soixante-dix", "correct": false}
+        ]
+      }
+    ],
+    "jour3": [
+      {
+        "question": "Selon D&A 107:22-24, comment la Première Présidence et le Quorum des Douze se comparent-ils ?",
+        "answers": [
+          {"text": "Les Douze apôtres sont égaux en autorité avec la Première Présidence comme témoins spéciaux", "correct": true},
+          {"text": "Les Douze servent uniquement dans leurs branches locales", "correct": false},
+          {"text": "Les Douze sont subordonnés aux soixante-dix en toute chose", "correct": false}
+        ]
+      },
+      {
+        "question": "Quel devoir particulier est donné aux Douze dans D&A 107:23 ?",
+        "answers": [
+          {"text": "Être témoins spéciaux du nom de Christ dans tout le monde", "correct": true},
+          {"text": "Administrer les finances de l'Église", "correct": false},
+          {"text": "Traduire toutes les Écritures en anglais moderne", "correct": false}
+        ]
+      },
+      {
+        "question": "Que décrit D&A 107:25-26 au sujet du grand conseil des douze grands prêtres ?",
+        "answers": [
+          {"text": "Ils forment un quorum qui juge les affaires les plus importantes de l'Église", "correct": true},
+          {"text": "Ils organisent les mariages civils", "correct": false},
+          {"text": "Ils remplacent la Première Présidence", "correct": false}
+        ]
+      },
+      {
+        "question": "Quelle responsabilité les soixante-dix reçoivent-ils selon D&A 107:34-35 ?",
+        "answers": [
+          {"text": "Prêcher l'Évangile sous la direction des Douze dans le monde entier", "correct": true},
+          {"text": "Administrer exclusivement les temples", "correct": false},
+          {"text": "Superviser les paroisses locales à plein temps", "correct": false}
+        ]
+      }
+    ],
+    "jour4": [
+      {
+        "question": "Quel principe D&A 107:99 enseigne-t-il à ceux qui reçoivent un appel ?",
+        "answers": [
+          {"text": "S'efforcer diligemment d'apprendre et d'accomplir son devoir", "correct": true},
+          {"text": "Attendre des instructions détaillées avant d'agir", "correct": false},
+          {"text": "Déléguer immédiatement la responsabilité à quelqu'un d'autre", "correct": false}
+        ]
+      },
+      {
+        "question": "Selon D&A 107:100, que se passe-t-il si quelqu'un néglige son appel ?",
+        "answers": [
+          {"text": "Il ne sera pas estimé et n'aura pas l'Esprit", "correct": true},
+          {"text": "Il sera libéré sans conséquence", "correct": false},
+          {"text": "Il recevra automatiquement un appel plus facile", "correct": false}
+        ]
+      },
+      {
+        "question": "Quel réconfort le Seigneur offre-t-il à Lyman Sherman dans D&A 108:1 ?",
+        "answers": [
+          {"text": "Ton péché t'est pardonné parce que tu t'es humilié", "correct": true},
+          {"text": "Tu dois quitter l'Église immédiatement", "correct": false},
+          {"text": "Tu ne recevras plus aucune révélation", "correct": false}
+        ]
+      },
+      {
+        "question": "Quel devoir D&A 108:7-8 donne-t-il à Lyman Sherman ?",
+        "answers": [
+          {"text": "Annoncer l'Évangile, prier avec foi et fortifier ses frères", "correct": true},
+          {"text": "Retourner à la ferme et s'y consacrer entièrement", "correct": false},
+          {"text": "Chercher des honneurs politiques dans la ville", "correct": false}
+        ]
+      }
+    ],
+    "jour5": [
+      {
+        "question": "Quel thème commun relie D&A 106 et 108 concernant le service local ?",
+        "answers": [
+          {"text": "Servir humblement pour fortifier les saints dans sa région", "correct": true},
+          {"text": "Se retirer complètement du monde", "correct": false},
+          {"text": "Rechercher d'abord les honneurs personnels", "correct": false}
+        ]
+      },
+      {
+        "question": "Selon D&A 107, pourquoi l'ordre du sacerdoce est-il essentiel ?",
+        "answers": [
+          {"text": "Afin que toutes choses soient faites en ordre et sous inspiration", "correct": true},
+          {"text": "Pour concentrer tout pouvoir sur une seule personne", "correct": false},
+          {"text": "Pour éviter toute activité missionnaire", "correct": false}
+        ]
+      },
+      {
+        "question": "Comment D&A 106:4-6 nous invite-t-il à nous préparer à la venue du Seigneur ?",
+        "answers": [
+          {"text": "En veillant comme des enfants de lumière", "correct": true},
+          {"text": "En calculant la date précise de son retour", "correct": false},
+          {"text": "En comptant sur la protection du gouvernement", "correct": false}
+        ]
+      },
+      {
+        "question": "Quel engagement personnel ressort de D&A 108:7-8 pour chaque disciple ?",
+        "answers": [
+          {"text": "Chercher l'Esprit par la prière et fortifier nos frères", "correct": true},
+          {"text": "Éviter toute responsabilité publique", "correct": false},
+          {"text": "Rechercher avant tout la prospérité matérielle", "correct": false}
+        ]
+      }
+    ]
   },
+
   "29 sept.–5 oct. | D&A 109–110": {
     "jour1": [],
     "jour2": [],


### PR DESCRIPTION
## Summary
- add the set of daily quiz questions and answers for "22–28 septembre | D&A 106–108"

## Testing
- python -m json.tool questions.json > /tmp/validated.json

------
https://chatgpt.com/codex/tasks/task_e_68df673026d8832c9ced5fe5bc0b298e